### PR TITLE
Add option to skip file types

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,45 @@ Using `autocmd` and `CursorMoved`/`CursorMovedI` events, `zz` is applied to ever
 Minorly optimized by only applying `zz` to vertical line movement.
 
 Should not get in the way of plugins like `auto-pairs` or `compe`, which tend to have their own mappings for `<CR>`.
+
+## Options
+
+If there are certain filetypes you'd like to omit from this functionality, you can do so by setting the following variable before enabling `stay-centered.nvim`:
+
+```
+vim.api.nvim_set_var('stay-centered#skip_filetypes', { "lua" })
+```
+
+The filetype is determined by the vim filetype, not the file extension. In order to get the filetype, open a file and run the command:
+
+```
+:vim.bo.filetype
+```
+
+#### Example
+
+```
+// someFile.ts
+
+const myVar
+...etc
+
+:lua print(vim.bo.filetype)
+#=> typescript
+```
+
+```
+// plugins.lua
+vim.api.nvim_set_var('stay-centered#skip_filetypes', { "typescript" })
+
+return packer.startup(
+  function()
+    use "wbthomason/packer.nvim"
+    use "arnamak/stay-centered.nvim"
+    ...
+  end
+)
+```
+Obviously, you can set that variable anywhere, so long as it is before you initialize `stay-centered`.
+
+You may specify multiple filetypes, comma separated, within the table.

--- a/lua/stay-centered.lua
+++ b/lua/stay-centered.lua
@@ -1,17 +1,28 @@
 local ac = vim.api.nvim_create_autocmd
 local ag = vim.api.nvim_create_augroup
 local getCursor = vim.api.nvim_win_get_cursor
+local skip_files = vim.g["stay-centered#skip_filetypes"]
+
+local function config_has_files_to_skip (t, v)
+  if t ~= nil then
+    for index, value in ipairs(t) do
+      if value == v then return true end
+    end
+  end
+end
 
 function StayCentered(inInsert)
-    local line = getCursor(0)[1]
-    if line ~= vim.b.last_line then
-        vim.cmd('norm! zz')
-        vim.b.last_line = line
-        if inInsert then
-            local column = vim.fn.getcurpos()[5]
-            vim.fn.cursor(line, column)
-        end
+  if config_has_files_to_skip(skip_files, vim.bo.filetype) then return false end
+
+  local line = getCursor(0)[1]
+  if line ~= vim.b.last_line then
+    vim.cmd('norm! zz')
+    vim.b.last_line = line
+    if inInsert then
+      local column = vim.fn.getcurpos()[5]
+      vim.fn.cursor(line, column)
     end
+  end
 end
 
 local group = ag('StayCentered', { clear = true })


### PR DESCRIPTION
Resolves #3 

Omit certain filetypes from staying centered.

Note: I've been out of the neovim/lua community for a while, so I am not sure if the syntax here is the most optimal. if anyone has suggestions, feel free to open a PR.