### PR TITLE
Allow scrolling to move cursor without centering

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,14 @@ use 'arnamak/stay-centered.nvim'
 require('stay-centered').setup({
   -- The filetype is determined by the vim filetype, not the file extension. In order to get the filetype, open a file and run the command:
   -- :lua print(vim.bo.filetype)
-  skip_filetypes = {}
+  skip_filetypes = {},
   -- Set to false to disable by default
   enabled = true,
   -- allows scrolling to move the cursor without centering, default recommended
   allow_scroll_move = true,
+  -- temporarily disables plugin on left-mouse down, allows natural mouse selection
+  -- try disabling if plugin causes lag, function uses vim.on_key
+  disable_on_mouse = true,
 })
 ```
 
@@ -70,7 +73,7 @@ use {
 
 ## Enabling/Disabling with Keymap
 
-`stay-centered.nvim` has built in functions `enable`, `disable`, and `toggle` to handle this behaviour.
+`stay-centered.nvim` has built-in functions `enable`, `disable`, and `toggle` to handle this behavior.
 
 Example for toggling on keymap:
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Using Packer:
 use 'arnamak/stay-centered.nvim'
 ```
 
-## Options
+## Options (Default)
 
 ```lua
 require('stay-centered').setup({
@@ -39,6 +39,8 @@ require('stay-centered').setup({
   skip_filetypes = {}
   -- Set to false to disable by default
   enabled = true,
+  -- allows scrolling to move the cursor without centering, default recommended
+  allow_scroll_move = true,
 })
 ```
 

--- a/lua/plugin.lua
+++ b/lua/plugin.lua
@@ -15,7 +15,7 @@ local function must_skip_file(skip_filetypes, current_type)
 end
 
 local function stay_centered(ctx)
-	if not ctx.cfg.enabled then
+	if not ctx.cfg.enabled or not ctx.cfg.active then
 		return
 	end
 	if must_skip_file(ctx.cfg.skip_filetypes, vim.bo.filetype) then

--- a/lua/plugin.lua
+++ b/lua/plugin.lua
@@ -28,12 +28,14 @@ local function stay_centered(ctx)
 	end
 
 	-- check if cursor moved from window scroll
-	if
-		(line == vim.fn.line("w0") and line > vim.b.last_line)
-		or (line == vim.fn.line("w$") and line < vim.b.last_line)
-	then
-		vim.b.last_line = line
-		return
+	if ctx.cfg.allow_scroll_move then
+		if
+			(line == vim.fn.line("w0") and line > vim.b.last_line)
+			or (line == vim.fn.line("w$") and line < vim.b.last_line)
+		then
+			vim.b.last_line = line
+			return
+		end
 	end
 
 	if line ~= vim.b.last_line then

--- a/lua/plugin.lua
+++ b/lua/plugin.lua
@@ -29,9 +29,11 @@ local function stay_centered(ctx)
 
 	-- check if cursor moved from window scroll
 	if ctx.cfg.allow_scroll_move then
+		local top = vim.fn.line("w0") + vim.o.scrolloff
+		local bottom = vim.fn.line("w$") - vim.o.scrolloff
 		if
-			(line == vim.fn.line("w0") and line > vim.b.last_line)
-			or (line == vim.fn.line("w$") and line < vim.b.last_line)
+			(line == top and line > vim.b.last_line)
+			or (line == bottom and line < vim.b.last_line)
 		then
 			vim.b.last_line = line
 			return

--- a/lua/plugin.lua
+++ b/lua/plugin.lua
@@ -23,6 +23,19 @@ local function stay_centered(ctx)
 	end
 
 	local line = vim.api.nvim_win_get_cursor(0)[1]
+	if vim.b.last_line == nil then
+		vim.b.last_line = line
+	end
+
+	-- check if cursor moved from window scroll
+	if
+		(line == vim.fn.line("w0") and line > vim.b.last_line)
+		or (line == vim.fn.line("w$") and line < vim.b.last_line)
+	then
+		vim.b.last_line = line
+		return
+	end
+
 	if line ~= vim.b.last_line then
 		vim.cmd("norm! zz")
 		vim.b.last_line = line

--- a/lua/plugin.lua
+++ b/lua/plugin.lua
@@ -31,10 +31,7 @@ local function stay_centered(ctx)
 	if ctx.cfg.allow_scroll_move then
 		local top = vim.fn.line("w0") + vim.o.scrolloff
 		local bottom = vim.fn.line("w$") - vim.o.scrolloff
-		if
-			(line == top and line > vim.b.last_line)
-			or (line == bottom and line < vim.b.last_line)
-		then
+		if (line <= top and line > vim.b.last_line) or (line >= bottom and line < vim.b.last_line) then
 			vim.b.last_line = line
 			return
 		end

--- a/lua/stay-centered.lua
+++ b/lua/stay-centered.lua
@@ -3,6 +3,7 @@ local M = {}
 M.cfg = {
 	skip_filetypes = {},
 	enabled = true,
+	allow_scroll_move = true,
 }
 
 M.setup = function(ctx)
@@ -13,6 +14,9 @@ M.setup = function(ctx)
 	M.cfg.skip_filetypes = ctx.skip_filetypes or {}
 	if type(ctx.enabled) == "boolean" then
 		M.cfg.enabled = ctx.enabled
+	end
+	if type(ctx.allow_scroll_move) == "boolean" then
+		M.cfg.allow_scroll_move = ctx.allow_scroll_move
 	end
 end
 

--- a/lua/stay-centered.lua
+++ b/lua/stay-centered.lua
@@ -2,8 +2,10 @@ local M = {}
 
 M.cfg = {
 	skip_filetypes = {},
-	enabled = true,
+	enabled = true, -- takes precedence over `active`
+	active = true, -- for internally disabling plugin behavior
 	allow_scroll_move = true,
+	disable_on_mouse = true,
 }
 
 M.setup = function(ctx)
@@ -17,6 +19,13 @@ M.setup = function(ctx)
 	end
 	if type(ctx.allow_scroll_move) == "boolean" then
 		M.cfg.allow_scroll_move = ctx.allow_scroll_move
+	end
+	if type(ctx.disable_on_mouse) == "boolean" then
+		M.cfg.disable_on_mouse = ctx.disable_on_mouse
+	end
+
+	if M.cfg.disable_on_mouse then
+		M.mcb_id = vim.on_key(M.mouse_callback)
 	end
 end
 
@@ -61,6 +70,30 @@ M.toggle = function()
 		M.disable()
 	else
 		M.enable()
+	end
+end
+
+M.activate = function()
+	M.cfg.active = true
+end
+
+M.deactivate = function()
+	M.cfg.active = false
+end
+
+M.mouse_callback = function(key, typed)
+	if not M.cfg.enabled then
+		return
+	end
+
+	if key == vim.api.nvim_replace_termcodes("<LeftMouse>", true, true, true) then
+		M.deactivate()
+	end
+	if key == vim.api.nvim_replace_termcodes("<LeftDrag>", true, true, true) then
+	end
+	if key == vim.api.nvim_replace_termcodes("<LeftRelease>", true, true, true) then
+		vim.b.last_line = vim.api.nvim_win_get_cursor(0)[1]
+		M.activate()
 	end
 end
 


### PR DESCRIPTION
Issue:
Scrolling the window (`<C-e>, <C-y>, mouse, etc.`) would center the screen if the cursor was at the top or bottom and the user scrolled down or up respectively. This made scrolling (especially with the mouse) very inconvenient when the plugin was active.

Fix:
Allows scrolling to move cursor by default, also provides option to use old behavior if the user wants