### PR TITLE
fix(stay_centered): ensure cursor stays in correct column after line deletion

### DIFF
--- a/lua/plugin.lua
+++ b/lua/plugin.lua
@@ -24,10 +24,10 @@ local function stay_centered(ctx)
 
 	local line = vim.api.nvim_win_get_cursor(0)[1]
 	if line ~= vim.b.last_line then
+		local column = vim.fn.getcurpos()[3]
 		vim.cmd("norm! zz")
 		vim.b.last_line = line
 		if ctx.mode == mode.insert then
-			local column = vim.fn.getcurpos()[5]
 			vim.fn.cursor({ line, column })
 		end
 	end


### PR DESCRIPTION
Previously, when deleting the last character of a line, the cursor would
incorrectly move to the non-last character of the previous line. 

This commit fixes the issue by:
1. Using `vim.fn.getcurpos()[3]` to get the actual column position (`col`)
   instead of the preferred column position (`curswant`).
2. Saving the actual column position before executing the `zz` command to
   ensure the cursor is restored to the correct column after the command.
