### PR TITLE
fix insert mode tab behaviour

### DIFF
--- a/lua/plugin.lua
+++ b/lua/plugin.lua
@@ -41,7 +41,13 @@ local function stay_centered(ctx)
 		vim.cmd("norm! zz")
 		vim.b.last_line = line
 		if ctx.mode == mode.insert then
-			local column = vim.fn.getcurpos()[5]
+			local target_column = vim.fn.getcurpos()[5]
+			local max_column = vim.fn.strdisplaywidth(vim.fn.getline("."))
+			local column = vim.fn.virtcol2col(0, line, target_column)
+			if target_column > max_column then
+				column = #vim.fn.getline(".") + 1
+			end
+
 			vim.fn.cursor({ line, column })
 		end
 	end


### PR DESCRIPTION
`getcurpos()[5]`, AKA `curswant`, is the virtual column number, rather than the byte index as expected by `cursor()`. Consequently, when moving between lines in insert mode (such as by `'<C-o>'`, `'j'`) to a position which is preceded by tabs, the cursor is adjusted incorrectly. This can also happen when entering insert mode from visual block mode with `'A'` or `'I'`. This only happens when the cursor is at the bottom of the block, because it jumps to the top before entering insert mode in that case.

The solution is to find the byte index corresponding to `curswant` (represented by the variable `target_column` in this code) with `virtcol2col()`. Due to the following behaviour described in [the documentation](https://neovim.io/doc/user/builtin.html#virtcol2col()),
>		If {col} is greater than the last virtual column in line
>		{lnum}, then the byte index of the character at the last
>		virtual column is returned.

when `target_column` is past the end of the line, `column` is overridden to be one greater than the number of bytes in the line.